### PR TITLE
Update Darker theme beta.cfg with lighter text in Console, Editor, an…

### DIFF
--- a/Darker theme beta/Darker theme beta.cfg
+++ b/Darker theme beta/Darker theme beta.cfg
@@ -36,25 +36,25 @@
         <FCParamGroup Name="OutputWindow">
           <FCUInt Name="colorText" Value="3570717951"/>
           <FCUInt Name="colorLogging" Value="1437270015"/>
-          <FCUInt Name="colorWarning" Value="4252787455"/>
+          <FCUInt Name="colorWarning" Value="4256589055"/>
           <FCUInt Name="colorError" Value="4278190335"/>
         </FCParamGroup>
         <FCParamGroup Name="Editor">
           <FCUInt Name="Text" Value="3570717696"/>
-          <FCUInt Name="Bookmark" Value="16776960"/>
+          <FCUInt Name="Bookmark" Value="2023406592"/>
           <FCUInt Name="Breakpoint" Value="4278190080"/>
-          <FCUInt Name="Keyword" Value="1453118976"/>
-          <FCUInt Name="Comment" Value="1788433664"/>
-          <FCUInt Name="Block comment" Value="3465639936"/>
+          <FCUInt Name="Keyword" Value="2226577664"/>
+          <FCUInt Name="Comment" Value="2579466240"/>
+          <FCUInt Name="Block comment" Value="2579466240"/>
           <FCUInt Name="Number" Value="3050219520"/>
-          <FCUInt Name="String" Value="3465639936"/>
+          <FCUInt Name="String" Value="3718686208"/>
           <FCUInt Name="Character" Value="4278190080"/>
           <FCUInt Name="Class name" Value="1321840640"/>
           <FCUInt Name="Define name" Value="3705448960"/>
           <FCUInt Name="Operator" Value="3570717696"/>
-          <FCUInt Name="Python output" Value="2863300352"/>
-          <FCUInt Name="Python error" Value="4252787200"/>
-          <FCUInt Name="Current line highlight" Value="524114944"/>
+          <FCUInt Name="Python output" Value="3739143680"/>
+          <FCUInt Name="Python error" Value="4254499072"/>
+          <FCUInt Name="Current line highlight" Value="0"/>
         </FCParamGroup>
         <FCParamGroup Name="View">
           <FCUInt Name="SketchEdgeColor" Value="4294967295"/>


### PR DESCRIPTION
Update Darker theme beta.cfg with lighter text in Console, Editor, and Report windows

Per https://github.com/FreeCAD/FreeCAD/issues/9841#issuecomment-1758609666

I updated the Darker theme beta to have higher contrast text, aiming at a WCAG AA rating based on using the https://dequeuniversity.com/color-contrast tool versus the #444444 background.

It's my new favorite.

Change to:

![https://user-images.githubusercontent.com/2236516/274466814-3b3e05c1-2e60-4ee3-ad28-875a37212258.png](https://user-images.githubusercontent.com/2236516/274466814-3b3e05c1-2e60-4ee3-ad28-875a37212258.png)

from default Darker theme beta:
![https://user-images.githubusercontent.com/2236516/274467230-4eb39a39-d2df-4fd1-8cf8-f91c3c5099c1.png](https://user-images.githubusercontent.com/2236516/274467230-4eb39a39-d2df-4fd1-8cf8-f91c3c5099c1.png)